### PR TITLE
use multiple streams to reduce the amount of useless message processi…

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -36,4 +36,4 @@ jobs:
     - name: Analysing the code with pylint
       run: |
         python_files=$(find . -name "*.py")
-        pylint --disable=line-too-long --disable=too-many-lines --disable=too-many-return-statements --disable=too-many-branches --disable=too-many-statements --disable=too-many-branches --disable=too-many-nested-blocks --disable=no-else-return --disable=too-many-arguments --disable=unused-argument --disable=invalid-name --disable=too-many-instance-attributes --disable=consider-using-with --disable=too-many-public-methods ${python_files}
+        pylint --disable=too-many-locals --disable=line-too-long --disable=too-many-lines --disable=too-many-return-statements --disable=too-many-branches --disable=too-many-statements --disable=too-many-branches --disable=too-many-nested-blocks --disable=no-else-return --disable=too-many-arguments --disable=unused-argument --disable=invalid-name --disable=too-many-instance-attributes --disable=consider-using-with --disable=too-many-public-methods ${python_files}


### PR DESCRIPTION
…ng for the participants

- using 3 streams: global, leader, and followers

- the leader only listens to the global and leader streams

- the followers only listen to the global and followers streams

- this allows participants to avoid processing messages that are not intended for them -- ie. the followers don't need to process messages that other followers send to the leader