### PR TITLE
feat: add controller image requirements and use release CI workflow

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -33,10 +33,10 @@ jobs:
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
-  call-real-core-crucible-ci:
+  call-real-core-release-crucible-ci:
     needs: changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
-    uses: perftool-incubator/crucible-ci/.github/workflows/core-crucible-ci.yaml@main
+    uses: perftool-incubator/crucible-ci/.github/workflows/core-release-crucible-ci.yaml@main
     with:
       ci_target: "roadblock"
       ci_target_branch: "${{ github.ref }}"
@@ -45,13 +45,13 @@ jobs:
       ci_registry_auth: ${{ secrets.CRUCIBLE_CI_ENGINES_REGISTRY_AUTH }}
       quay_oauth_token: ${{ secrets.CRUCIBLE_QUAYIO_OAUTH_TOKEN }}
 
-  call-faux-core-crucible-ci:
+  call-faux-core-release-crucible-ci:
     needs: changes
     if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
-    uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-crucible-ci.yaml@main
+    uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-release-crucible-ci.yaml@main
 
   crucible-ci-complete:
-    needs: [ call-real-core-crucible-ci, call-faux-core-crucible-ci ]
+    needs: [ call-real-core-release-crucible-ci, call-faux-core-release-crucible-ci ]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/workshop.json
+++ b/workshop.json
@@ -12,6 +12,14 @@
 		"hiredis",
 		"python-jsonschema"
 	    ]
+	},
+	{
+	    "name": "crucible-controller",
+	    "requirements": [
+		"python-redis",
+		"hiredis",
+		"python-jsonschema"
+	    ]
 	}
     ],
     "requirements": [


### PR DESCRIPTION
## Summary
- Add `crucible-controller` userenv entry to `workshop.json` so roadblock's Python dependencies (redis, hiredis, jsonschema) are declared here rather than centrally in crucible's `controller-workshop.json`
- Switch `crucible-ci.yaml` from `core-crucible-ci` to `core-release-crucible-ci` so workshop.json changes trigger a controller image rebuild

Part of the effort to decentralize controller image requirements to individual subprojects.

## Test plan
- [ ] CI passes
- [ ] Controller image builds successfully with roadblock deps resolved from this workshop.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)