### PR TITLE
fix: catch ValidationError, add stream_add backoff, remove duplicate check

### DIFF
--- a/roadblock.py
+++ b/roadblock.py
@@ -1237,9 +1237,11 @@ class roadblock:
             except redis.exceptions.ConnectionError as con_error:
                 logger.error("%s", con_error)
                 logger.error("Stream add to '%s' failed due to connection error!", stream_name)
+                ret_val = None
             except redis.exceptions.TimeoutError as con_error:
                 logger.error("%s", con_error)
                 logger.error("Stream add to '%s' failed due to a timeout error!", stream_name)
+                ret_val = None
 
             if ret_val is None:
                 logger.warning("Failed attempt %d to add message '%s' to stream '%s'", counter, message, stream_name)

--- a/roadblock.py
+++ b/roadblock.py
@@ -571,8 +571,6 @@ class roadblock:
             incomplete_message = True
         elif not "id" in message["payload"]["sender"]:
             incomplete_message = True
-        elif not "recipient" in message["payload"]:
-            incomplete_message = True
         elif not "type" in message["payload"]["recipient"]:
             incomplete_message = True
 

--- a/roadblock.py
+++ b/roadblock.py
@@ -549,7 +549,7 @@ class roadblock:
                 jsonschema.validate(instance=message, schema=self.schema)
                 logger.debug("message passed schema validation [%s]", self.message_to_str(message))
 
-            except jsonschema.exceptions.SchemaError:
+            except jsonschema.exceptions.ValidationError:
                 logger.error("message failed schema validation [%s]", self.message_to_str(message))
                 return False
 
@@ -1835,7 +1835,7 @@ class roadblock:
 
             try:
                 jsonschema.validate(instance=self.user_messages, schema=self.user_schema)
-            except jsonschema.exceptions.SchemaError as exception:
+            except jsonschema.exceptions.ValidationError as exception:
                 logger.critical(exception)
                 logger.critical("Could not JSON validate the user messages!")
                 return self.RC_INVALID_INPUT


### PR DESCRIPTION
## Summary

Three fixes, one per commit:

- **SchemaError → ValidationError**: `message_validate()` and user message validation caught `SchemaError` (malformed schema) instead of `ValidationError` (data fails validation). Actual validation failures propagated as unhandled exceptions.

- **stream_add backoff on connection errors**: On `ConnectionError`/`TimeoutError`, `ret_val` stayed at `0` so the `is None` backoff check didn't fire. The while loop retried immediately with no delay. Fix: set `ret_val = None` in exception handlers so existing backoff logic applies.

- **Duplicate recipient check**: `message_for_me()` checked `not "recipient" in message["payload"]` twice in the elif chain (lines 568 and 574). The second was unreachable.

Note: The `message_build_custom` call on line 1965 with `sender_id="personal-stream-created"` is intentional — it prevents the self-sender filter in `message_for_me()` from dropping the personal stream creation message.

Closes #89

## Test plan
- [ ] Run `test/run-test.sh` — exercises barrier sync, timeout, abort, and wait-for scenarios
- [ ] Verify invalid user message JSON produces a logged validation error instead of an unhandled exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)